### PR TITLE
Implement instructors search endpoint

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -752,6 +752,7 @@ public final class Const {
         public static final String INSTRUCTORS = "/instructors";
         public static final String INSTRUCTOR = "/instructor";
         public static final String INSTRUCTOR_PRIVILEGE = "/instructor/privilege";
+        public static final String INSTRUCTORS_SEARCH = "/search/instructors";
         public static final String RESULT = "/result";
         public static final String STUDENTS = "/students";
         public static final String STUDENT = "/student";

--- a/src/main/java/teammates/ui/webapi/action/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/action/ActionFactory.java
@@ -57,6 +57,7 @@ public class ActionFactory {
         map(ResourceURIs.INSTRUCTOR, DELETE, DeleteInstructorAction.class);
         map(ResourceURIs.INSTRUCTOR_PRIVILEGE, GET, GetInstructorPrivilegeAction.class);
         map(ResourceURIs.INSTRUCTOR_PRIVILEGE, PUT, UpdateInstructorPrivilegeAction.class);
+        map(ResourceURIs.INSTRUCTORS_SEARCH, GET, SearchInstructorsAction.class);
         map(ResourceURIs.RESPONSE_COMMENT, POST, CreateFeedbackResponseCommentAction.class);
         map(ResourceURIs.RESPONSE_COMMENT, PUT, UpdateFeedbackResponseCommentAction.class);
         map(ResourceURIs.RESPONSE_COMMENT, DELETE, DeleteFeedbackResponseCommentAction.class);

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -1,0 +1,35 @@
+package teammates.ui.webapi.action;
+
+import java.util.List;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.ui.webapi.output.SearchInstructorsData;
+
+/**
+ * Searches for instructors.
+ */
+public class SearchInstructorsAction extends Action {
+
+    @Override
+    protected AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    public void checkSpecificAccessControl() {
+        // Only admins can search for instructors
+        if (!userInfo.isAdmin) {
+            throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
+        }
+    }
+
+    @Override
+    public ActionResult execute() {
+        String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
+        List<InstructorAttributes> instructors = logic.searchInstructorsInWholeSystem(searchKey).instructorList;
+        SearchInstructorsData result = new SearchInstructorsData(instructors);
+        return new JsonResult(result);
+    }
+}

--- a/src/main/java/teammates/ui/webapi/output/SearchInstructorsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SearchInstructorsData.java
@@ -1,0 +1,20 @@
+package teammates.ui.webapi.output;
+
+import java.util.List;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+
+/**
+ * Output format for instructor search result.
+ */
+public class SearchInstructorsData extends ApiOutput {
+    private final List<InstructorAttributes> instructors;
+
+    public SearchInstructorsData(List<InstructorAttributes> instructors) {
+        this.instructors = instructors;
+    }
+
+    public List<InstructorAttributes> getInstructors() {
+        return instructors;
+    }
+}

--- a/src/test/java/teammates/test/cases/webapi/SearchInstructorsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/SearchInstructorsActionTest.java
@@ -1,0 +1,129 @@
+package teammates.test.cases.webapi;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.Const;
+import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.action.SearchInstructorsAction;
+import teammates.ui.webapi.output.SearchInstructorsData;
+
+/**
+ * SUT: {@link SearchInstructorsAction}.
+ */
+public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructorsAction> {
+
+    private final InstructorAttributes acc = typicalBundle.instructors.get("instructor1OfCourse1");
+
+    @Override
+    protected void prepareTestData() {
+        DataBundle dataBundle = getTypicalDataBundle();
+        removeAndRestoreDataBundle(dataBundle);
+        putDocuments(dataBundle);
+    }
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.INSTRUCTORS_SEARCH;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Override
+    @Test
+    protected void testExecute() {
+        // See test cases below.
+    }
+
+    @Test
+    protected void testExecute_notEnoughParameters_shouldFail() {
+        loginAsAdmin();
+        verifyHttpParameterFailure();
+    }
+
+    @Test
+    protected void testExecute_searchCourseId_shouldSucceed() {
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.ADMIN_SEARCH_KEY, acc.getCourseId() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        SearchInstructorsData response = (SearchInstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchDisplayedName_shouldSucceed() {
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.ADMIN_SEARCH_KEY, acc.getDisplayedName() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        SearchInstructorsData response = (SearchInstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchEmail_shouldSucceed() {
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.ADMIN_SEARCH_KEY, acc.getEmail() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        SearchInstructorsData response = (SearchInstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchGoogleId_shouldSucceed() {
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.ADMIN_SEARCH_KEY, acc.getGoogleId() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        SearchInstructorsData response = (SearchInstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchName_shouldSucceed() {
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.ADMIN_SEARCH_KEY, acc.getName() };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        SearchInstructorsData response = (SearchInstructorsData) result.getOutput();
+        assertTrue(response.getInstructors().stream()
+                .filter(i -> i.getName().equals(acc.getName()))
+                .findAny()
+                .isPresent());
+    }
+
+    @Test
+    protected void testExecute_searchNoMatch_shouldBeEmpty() {
+        loginAsAdmin();
+        String[] submissionParams = new String[] { Const.ParamsNames.ADMIN_SEARCH_KEY, "noMatch" };
+        SearchInstructorsAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        SearchInstructorsData response = (SearchInstructorsData) result.getOutput();
+        assertEquals(0, response.getInstructors().size());
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() {
+        verifyOnlyAdminCanAccess();
+    }
+
+}


### PR DESCRIPTION
This PR implements the `/search/instructors` endpoint which returns a list of `InstructorAttributes` objects. 

Old object: 

```json
{
  "students": [], 
  "instructors": [
    {
      "name": "John Dorian",
      "email": "teammates.instructor@university.edu",
      "googleId": "test@example.com",
      "courseId": "teammates.instructor.uni-demo",
      "courseName": "Sample Course 101",
      "institute": "National University of Singapore",
      "courseJoinLink": "...",
      "homePageLink": "...",
      "manageAccountLink": "...",
      "showLinks": false
    }
  ],
  "requestId": "5e4bfdac000294289e1b6ff7"
}
```

New object: 

```json
{
  "instructors": [
    {
      "courseId": "teammates.instructor.uni-demo",
      "email": "teammates.instructor@university.edu",
      "name": "John Dorian",
      "googleId": "test@example.com",
      "key": "teammates.instructor@university.edu%teammates.instructor.uni-demo-1812026140",
      "role": "Co-owner",
      "displayedName": "Instructor",
      "isArchived": false,
      "isDisplayedToStudents": true,
      "privileges": {
        "courseLevel": {
          "canviewstudentinsection": true,
          "cansubmitsessioninsection": true,
          "canmodifysessioncommentinsection": true,
          "canmodifycourse": true,
          "canviewsessioninsection": true,
          "canmodifysession": true,
          "canmodifystudent": true,
          "canmodifyinstructor": true
        },
        "sectionLevel": {},
        "sessionLevel": {}
      }
    }
  ],
  "requestId": "5e4bfdcf00050528f160baba"
}
```

Quite a bit of extra fields, we might want to consider trimming it down to mimic the old object? 